### PR TITLE
clear cache at end of benchmark run

### DIFF
--- a/pkg/command/dockerenv.go
+++ b/pkg/command/dockerenv.go
@@ -16,18 +16,21 @@ func RunDockerEnv(image string, profile string) (float64, error) {
 	}
 	elapsed := time.Now().Sub(start)
 
+	return elapsed.Seconds(), nil
+}
+
+func ClearDockerEnvCache(profile string) error {
 	// delete image to prevent caching
 	deleteArgs := fmt.Sprintf("eval $(./minikube -p %s docker-env) && docker image rm benchmark-env:latest", profile)
 	deleteImage := exec.Command("/bin/bash", "-c", deleteArgs)
 	if _, err := run(deleteImage); err != nil {
-		return 0, fmt.Errorf("failed to delete image: %v", err)
+		return fmt.Errorf("failed to delete image: %v", err)
 	}
-
 	// clear builder cache, must be run after the image delete
 	clearBuilderCacheArgs := fmt.Sprintf("eval $(./minikube -p %s docker-env) && docker builder prune -f", profile)
 	clearBuilderCache := exec.Command("/bin/bash", "-c", clearBuilderCacheArgs)
 	if _, err := run(clearBuilderCache); err != nil {
-		return 0, fmt.Errorf("failed to clear builder cache: %v", err)
+		return fmt.Errorf("failed to clear builder cache: %v", err)
 	}
-	return elapsed.Seconds(), nil
+	return nil
 }

--- a/pkg/command/imageload.go
+++ b/pkg/command/imageload.go
@@ -33,23 +33,27 @@ func RunImageLoad(image string, profile string) (float64, error) {
 		return 0, fmt.Errorf("image was not found after image load")
 	}
 
+	return elapsed.Seconds(), nil
+}
+
+func ClearImageLoadCache(profile string) error {
 	// delete image from minikube to prevent caching
 	deleteMinikubeImageArgs := fmt.Sprintf("eval $(./minikube -p %s docker-env) && docker image rm benchmark-image:latest", profile)
 	deleteMinikubeImage := exec.Command("/bin/bash", "-c", deleteMinikubeImageArgs)
 	if _, err := run(deleteMinikubeImage); err != nil {
-		return 0, fmt.Errorf("failed to delete minikube image: %v", err)
+		return fmt.Errorf("failed to delete minikube image: %v", err)
 	}
 
 	// delete image from Docker to prevent caching
 	deleteDockerImage := exec.Command("docker", "image", "rm", "benchmark-image:latest")
 	if _, err := run(deleteDockerImage); err != nil {
-		return 0, fmt.Errorf("failed to delete docker image: %v", err)
+		return fmt.Errorf("failed to delete docker image: %v", err)
 	}
 
 	// clear builder cache, must be run after the image delete
 	clearBuildCache := exec.Command("docker", "builder", "prune", "-f")
 	if _, err := run(clearBuildCache); err != nil {
-		return 0, fmt.Errorf("failed to clear builder cache: %v", err)
+		return fmt.Errorf("failed to clear builder cache: %v", err)
 	}
-	return elapsed.Seconds(), nil
+	return nil
 }

--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -46,3 +46,7 @@ func RunRegistry(image string, profile string) (float64, error) {
 
 	return elapsed.Seconds(), nil
 }
+
+func ClearRegistryCache(profile string) error {
+	return nil
+}


### PR DESCRIPTION
Currently the cache is cleared after every build, but this doesn't accurately represent the use case we're trying to replicate, now the cache is only cleared after all the the runs for the benchmark is complete.