### PR TITLE
Added auto-setting docker insecure registry address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
+.PHONY: all
 all:
 	go build -o out/benchmark cmd/benchmark.go

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -28,6 +28,17 @@ func main() {
 	}
 	defer command.DeleteMinikube(*profile)
 
+	if err := command.SetDockerInsecureRegistry(*profile); err != nil {
+		log.Printf("failed to set docker insecre registry: %v", err)
+		return
+	}
+
+	// StartDockerInsecureRegistry restarts Docker, so need to start minikube again
+	if err := command.StartMinikube(*profile); err != nil {
+		log.Printf("failed to start minikube: %v", err)
+		return
+	}
+
 	results, err := benchmark.Run(*runs, *profile)
 	if err != nil {
 		log.Printf("failed running benchmarks: %v", err)

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -25,7 +25,7 @@ type method struct {
 
 var Images = []string{"alpineFewLargeFiles", "alpineFewSmallFiles", "ubuntuFewLargeFiles", "ubuntuFewSmallFiles"}
 var Methods = []string{"image load", "docker-env", "registry"}
-var Iter = []string{ "iterative", " non-iterative"}
+var Iter = []string{" iterative", " non-iterative"}
 var methods = []method{
 	{
 		command.RunImageLoad,

--- a/pkg/command/dockerregistry.go
+++ b/pkg/command/dockerregistry.go
@@ -1,0 +1,41 @@
+package command
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// SetDockerInsecureRegistry sets minikube's IP in Docker's insecure registry
+func SetDockerInsecureRegistry(profile string) error {
+	// get minikue IP
+	ip, err := minikubeIP(profile)
+	if err != nil {
+		return err
+	}
+
+	// create docker daemon.json
+	thing := "sudo touch /etc/docker/daemon.json"
+	c = exec.Command("/bin/bash", "-c", thing)
+	if _, err := run(c); err != nil {
+		return fmt.Errorf("failed to create file: %v", err)
+	}
+
+	// set IP in Docker insecure registry
+	args := fmt.Sprintf(`sudo tee /etc/docker/daemon.json << EOF
+{
+  "insecure-registries" : ["%s:5000"]
+}
+EOF`, ip)
+	c = exec.Command("/bin/bash", "-c", args)
+	if _, err = run(c); err != nil {
+		return fmt.Errorf("failed to set insecure registry: %v", err)
+	}
+
+	// restart Docker so changes take effect
+	c = exec.Command("sudo", "service", "docker", "restart")
+	if _, err = run(c); err != nil {
+		return fmt.Errorf("failed to restart docker: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/command/minikube.go
+++ b/pkg/command/minikube.go
@@ -28,3 +28,15 @@ func DeleteMinikube(profile string) error {
 	}
 	return nil
 }
+
+func minikubeIP(profile string) (string, error) {
+	c := exec.Command("./minikube", "-p", profile, "ip")
+	ip, err := run(c)
+	if err != nil {
+		return "", fmt.Errorf("failed to get minikube ip: %v", err)
+	}
+	// output contains newline char, strip it out
+	ip = ip[:len(ip)-1]
+
+	return ip, nil
+}

--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -26,13 +26,10 @@ func RunRegistry(image string, profile string) (float64, error) {
 	elapsed := time.Now().Sub(start)
 
 	// verify
-	getIP := exec.Command("./minikube", "-p", profile, "ip")
-	ip, err := run(getIP)
+	ip, err := minikubeIP(profile)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get minikube ip: %v", err)
+		return 0, err
 	}
-	// output contains newline char, strip it out
-	ip = ip[:len(ip)-1]
 
 	verifyArgs := fmt.Sprintf("curl http://%s:5000/v2/_catalog | grep benchmark-registry", ip)
 	verify := exec.Command("/bin/bash", "-c", verifyArgs)


### PR DESCRIPTION
In order to push to minikube's registry addon you have to set minikube's IP in Docker's insecure registry list (https://docs.docker.com/registry/insecure/#deploy-a-plain-http-registry).

Added a new func SetDockerInsecureRegistry that gets minikube's IP, adds it to Docker's insecure registry list, and then restarts Docker.