### PR TITLE
Removed --no-cache flags from docker build commands

### DIFF
--- a/pkg/command/dockerenv.go
+++ b/pkg/command/dockerenv.go
@@ -8,7 +8,7 @@ import (
 
 func RunDockerEnv(image string, profile string) (float64, error) {
 	// build
-	buildArgs := fmt.Sprintf("eval $(./minikube -p %s docker-env) && docker build --no-cache -t benchmark-env -f testdata/Dockerfile.%s .", profile, image)
+	buildArgs := fmt.Sprintf("eval $(./minikube -p %s docker-env) && docker build -t benchmark-env -f testdata/Dockerfile.%s .", profile, image)
 	build := exec.Command("/bin/bash", "-c", buildArgs)
 	start := time.Now()
 	if _, err := run(build); err != nil {

--- a/pkg/command/imageload.go
+++ b/pkg/command/imageload.go
@@ -9,7 +9,7 @@ import (
 func RunImageLoad(image string, profile string) (float64, error) {
 	// build
 	dockerfile := fmt.Sprintf("testdata/Dockerfile.%s", image)
-	build := exec.Command("docker", "build", "--no-cache", "-t", "benchmark-image", "-f", dockerfile, ".")
+	build := exec.Command("docker", "build", "-t", "benchmark-image", "-f", dockerfile, ".")
 	start := time.Now()
 	if _, err := run(build); err != nil {
 		return 0, fmt.Errorf("failed to build via image load: %v", err)

--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -10,7 +10,7 @@ func RunRegistry(image string, profile string) (float64, error) {
 	// build
 	dockerfile := fmt.Sprintf("testdata/Dockerfile.%s", image)
 	tag := fmt.Sprintf("$(./minikube -p %s ip):5000/benchmark-registry", profile)
-	buildArgs := fmt.Sprintf("docker build --no-cache -t %s -f %s .", tag, dockerfile)
+	buildArgs := fmt.Sprintf("docker build -t %s -f %s .", tag, dockerfile)
 	build := exec.Command("/bin/bash", "-c", buildArgs)
 	start := time.Now()
 	if _, err := run(build); err != nil {


### PR DESCRIPTION
Currently, all benchmarks, non-iterative or iterative, are using the --no-cache flag. The non-iterative benchmarks should not be using the flag as in a real world use case the cache would be used.

Initially added the --no-cache flags to prevent the non-iterative benchmarks from using cache to prevent consecutive builds from having faster builds and not being truly non-iterative.

However, since non-iterative build have the cache cleared in-between runs, can safely remove the --no-cache flag and both iterative and non-iterative builds will have the ideal work case.