### PR TITLE
Start new minikube instance for each benchmarking method

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -7,7 +7,6 @@ import (
 	"log"
 
 	"benchmark/pkg/benchmark"
-	"benchmark/pkg/command"
 	"benchmark/pkg/csv"
 	"benchmark/pkg/download"
 )
@@ -23,23 +22,6 @@ func main() {
 
 	if err := download.Files(); err != nil {
 		log.Fatal(err)
-	}
-
-	if err := command.StartMinikube(*profile); err != nil {
-		log.Fatal(err)
-	}
-	defer command.DeleteMinikube(*profile)
-	defer command.DockerSystemPrune()
-
-	if err := command.SetDockerInsecureRegistry(*profile); err != nil {
-		log.Printf("failed to set docker insecre registry: %v", err)
-		return
-	}
-
-	// StartDockerInsecureRegistry restarts Docker, so need to start minikube again
-	if err := command.StartMinikube(*profile); err != nil {
-		log.Printf("failed to start minikube: %v", err)
-		return
 	}
 
 	results, err := benchmark.Run(*runs, *profile)

--- a/pkg/command/dockerenv.go
+++ b/pkg/command/dockerenv.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+// StartMinikubeDockerEnv starts minikube for docker-env.
+func StartMinikubeDockerEnv(profile string) error {
+	return startMinikube(profile, "docker")
+}
+
 // RunDockerEnv builds the provided image using the docker-env method and returns the run time.
 func RunDockerEnv(image string, profile string) (float64, error) {
 	// build

--- a/pkg/command/dockerregistry.go
+++ b/pkg/command/dockerregistry.go
@@ -5,8 +5,8 @@ import (
 	"os/exec"
 )
 
-// SetDockerInsecureRegistry sets minikube's IP in Docker's insecure registry
-func SetDockerInsecureRegistry(profile string) error {
+// setDockerInsecureRegistry sets minikube's IP in Docker's insecure registry
+func setDockerInsecureRegistry(profile string) error {
 	// get minikue IP
 	ip, err := minikubeIP(profile)
 	if err != nil {
@@ -14,14 +14,14 @@ func SetDockerInsecureRegistry(profile string) error {
 	}
 
 	// create docker daemon.json
-	thing := "sudo touch /etc/docker/daemon.json"
-	c := exec.Command("/bin/bash", "-c", thing)
+	args := "sudo touch /etc/docker/daemon.json"
+	c := exec.Command("/bin/bash", "-c", args)
 	if _, err := run(c); err != nil {
 		return fmt.Errorf("failed to create file: %v", err)
 	}
 
 	// set IP in Docker insecure registry
-	args := fmt.Sprintf(`sudo tee /etc/docker/daemon.json << EOF
+	args = fmt.Sprintf(`sudo tee /etc/docker/daemon.json << EOF
 {
   "insecure-registries" : ["%s:5000"]
 }

--- a/pkg/command/imageload.go
+++ b/pkg/command/imageload.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+// StartMinikubeImageLoad starts minikube for docker-env.
+func StartMinikubeImageLoad(profile string) error {
+	return startMinikube(profile, "docker")
+}
+
 // RunImageLoad builds the provided image using the image load method and returns the run time.
 func RunImageLoad(image string, profile string) (float64, error) {
 	// build

--- a/pkg/command/minikube.go
+++ b/pkg/command/minikube.go
@@ -5,29 +5,31 @@ import (
 	"os/exec"
 )
 
-// StartMinikube starts minikube and enables the registry addon.
-func StartMinikube(profile string) error {
-	fmt.Printf("Starting minikube...\n")
-	start := exec.Command("./minikube", "start", "-p", profile, "--driver", "docker")
-	if _, err := run(start); err != nil {
+func startMinikube(profile string, driver string) error {
+	c := exec.Command("./minikube", "start", "-p", profile, "--driver", driver)
+	if _, err := run(c); err != nil {
 		return fmt.Errorf("failed to start minikube: %v", err)
 	}
 
-	enableRegistry := exec.Command("./minikube", "-p", profile, "addons", "enable", "registry")
-	if _, err := run(enableRegistry); err != nil {
-		DeleteMinikube(profile)
-		return fmt.Errorf("failed to enable registry addon: %v", err)
-	}
 	return nil
 }
 
-// DeleteMinikube deletes minikube.
+func enableRegistryAddon(profile string) error {
+	c := exec.Command("./minikube", "-p", profile, "addons", "enable", "registry")
+	if _, err := run(c); err != nil {
+		return fmt.Errorf("failed to enable registry addon: %v", err)
+	}
+
+	return nil
+}
+
+// DeleteMinikube deletes the minikube cluster.
 func DeleteMinikube(profile string) error {
-	fmt.Printf("Deleting minikube...\n")
-	delete := exec.Command("./minikube", "delete", "-p", profile)
-	if _, err := run(delete); err != nil {
+	c := exec.Command("./minikube", "delete", "--all")
+	if _, err := run(c); err != nil {
 		return fmt.Errorf("failed to delete minikube: %v", err)
 	}
+
 	return nil
 }
 

--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -6,6 +6,24 @@ import (
 	"time"
 )
 
+// StartMinikubeRegistry starts minikube for docker-env.
+func StartMinikubeRegistry(profile string) error {
+	if err := startMinikube(profile, "docker"); err != nil {
+		return err
+	}
+
+	if err := setDockerInsecureRegistry(profile); err != nil {
+		return err
+	}
+
+	// setDockerInsecureRegistry restarts docker, so minikube needs to be restarted
+	if err := startMinikube(profile, "docker"); err != nil {
+		return err
+	}
+
+	return enableRegistryAddon(profile)
+}
+
 // RunRegistry builds and pushes the provided image using the registry addon method and returns the run time.
 func RunRegistry(image string, profile string) (float64, error) {
 	// build


### PR DESCRIPTION
Before this PR, minikube was started in the cmd file. The problem with this is that new benchmarking methods will need to be started differently. For example, currently we start minikube with the docker driver, but buildkit needs minikube to be started with containerd.

To address this issue I refactored the code so that now a new minikube instance is started before each method is started and deleted after the method is done testing.
Example: Start minikube for docker-env -> run all docker-env benchmarks -> delete minikube -> repeat for all methods

This also makes sure that minikube is clean before each method run which is a good side effect.