### PR TITLE
fix: fix minikube registry docker

### DIFF
--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -8,7 +8,7 @@ import (
 
 // StartMinikubeRegistryDocker starts minikube for docker registry.
 func StartMinikubeRegistryDocker(profile string) error {
-	return startMinikube(profile, "docker")
+	return startMinikubeRegistry(profile, "docker")
 }
 
 // StartMinikubeRegistryContainerd starts minikube for containerd registry.


### PR DESCRIPTION
fix: fix minikube registry docker
**Before: (part of test log)**
```
Running buildpacksFewLargeFiles on registry docker iterative
2023/10/08 00:27:31 failed to run benchmark registry docker: failed running benchmark buildpacksFewLargeFiles on registry docker iterative: failed to push via registry: 
command: /bin/bash -c docker push $(./minikube -p benchmark ip):5000/benchmark-registry
command output: Using default tag: latest
The push refers to repository [192.168.49.2:5000/benchmark-registry]
Get "https://192.168.49.2:5000/v2/": dial tcp 192.168.49.2:5000: connect: connection refused

err: exit status 1
```

**After(part of test log)**
```
Running buildpacksFewLargeFiles on registry docker iterative
Run #1  took 65.02 seconds
Run #2  took 1.52 seconds
```