### PR TITLE
feat: support selecting testcase and memory limit in arguments

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -15,6 +15,14 @@ import (
 func main() {
 	runs := flag.Int("runs", 100, "number of runs per benchmark")
 	profile := flag.String("profile", "benchmark", "profile to use for minikube commands")
+	// images is a list of images we use, seperated by ,
+	images := flag.String("images", "", "a comma separated list of images to benchmark")
+
+	benchFlows := flag.String("iters", "iterative,non-iterative", "a comma separated list of flows to benchmark, options [iterative,non-iterative]")
+
+	benchMethods := flag.String("bench-methods", "", "a comma separated list of benchmark method names")
+	memory := flag.String("memory", "", "Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g). Use \"max\" to use the maximum amount of memory")
+
 	flag.Parse()
 
 	if *runs <= 0 {
@@ -27,7 +35,11 @@ func main() {
 
 	defer command.Delete()
 
-	results, err := benchmark.Run(*runs, *profile)
+	extraMinikubeStartArgs := []string{}
+	if *memory != "" {
+		extraMinikubeStartArgs = append(extraMinikubeStartArgs, "--memory="+*memory)
+	}
+	results, err := benchmark.Run(*runs, benchmark.NewBenchMarkRunConfig(*profile, *images, *benchFlows, *benchMethods, extraMinikubeStartArgs))
 	if err != nil {
 		log.Printf("failed running benchmarks: %v", err)
 		return

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -15,7 +15,6 @@ import (
 func main() {
 	runs := flag.Int("runs", 100, "number of runs per benchmark")
 	profile := flag.String("profile", "benchmark", "profile to use for minikube commands")
-	// images is a list of images we use, seperated by ,
 	images := flag.String("images", "", "a comma separated list of images to benchmark")
 
 	benchFlows := flag.String("iters", "iterative,non-iterative", "a comma separated list of flows to benchmark, options [iterative,non-iterative]")

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -16,9 +16,7 @@ func main() {
 	runs := flag.Int("runs", 100, "number of runs per benchmark")
 	profile := flag.String("profile", "benchmark", "profile to use for minikube commands")
 	images := flag.String("images", "", "a comma separated list of images to benchmark")
-
 	benchFlows := flag.String("iters", "iterative,non-iterative", "a comma separated list of flows to benchmark, options [iterative,non-iterative]")
-
 	benchMethods := flag.String("bench-methods", "", "a comma separated list of benchmark method names")
 	memory := flag.String("memory", "", "Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g). Use \"max\" to use the maximum amount of memory")
 

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -36,7 +36,7 @@ func main() {
 	if *memory != "" {
 		extraMinikubeStartArgs = append(extraMinikubeStartArgs, "--memory="+*memory)
 	}
-	results, err := benchmark.Run(*runs, benchmark.NewBenchMarkRunConfig(*profile, *images, *benchFlows, *benchMethods, extraMinikubeStartArgs))
+	results, err := benchmark.Run(*runs, benchmark.NewBenchmarkRunConfig(*profile, *images, *benchFlows, *benchMethods, extraMinikubeStartArgs))
 	if err != nil {
 		log.Printf("failed running benchmarks: %v", err)
 		return

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -31,7 +31,7 @@ type BenchmarkRunConfig struct {
 }
 
 func NewBenchmarkRunConfig(profile, imageList, iterList, benchMethodList string, minikubeStartArgs []string) *BenchmarkRunConfig {
-	res := BenchMarkRunConfig{
+	res := BenchmarkRunConfig{
 		BenchMethods:      make(map[string]struct{}),
 		Iters:             make(map[string]struct{}),
 		Images:            make(map[string]struct{}),

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -30,7 +30,7 @@ type BenchmarkRunConfig struct {
 	Profile           string
 }
 
-func NewBenchMarkRunConfig(profile, imageList, iterList, benchMethodList string, minikubeStartArgs []string) *BenchMarkRunConfig {
+func NewBenchmarkRunConfig(profile, imageList, iterList, benchMethodList string, minikubeStartArgs []string) *BenchmarkRunConfig {
 	res := BenchMarkRunConfig{
 		BenchMethods:      make(map[string]struct{}),
 		Iters:             make(map[string]struct{}),

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -22,7 +22,7 @@ type aggregatedRunResult struct {
 // AggregatedResultsMatrix is a map containing the run results for every image method combination.
 type AggregatedResultsMatrix map[string]map[string]aggregatedRunResult
 
-type BenchMarkRunConfig struct {
+type BenchmarkRunConfig struct {
 	BenchMethods      map[string]struct{}
 	Iters             map[string]struct{}
 	Images            map[string]struct{}

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -38,10 +38,8 @@ func NewBenchmarkRunConfig(profile, imageList, iterList, benchMethodList string,
 		MinikubeStartArgs: minikubeStartArgs,
 		Profile:           profile,
 	}
-	var split []string
-	if imageList == "" {
-		split = Images
-	} else {
+	split := Images
+	if imageList != "" {
 		split = strings.Split(imageList, ",")
 	}
 	for _, image := range split {

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -170,7 +170,7 @@ var BenchMethods = []method{
 	}}
 
 // Run runs all the benchmarking combinations and returns the average run time and standard deviation for each combination.
-func Run(runs int, config *BenchMarkRunConfig) (AggregatedResultsMatrix, error) {
+func Run(runs int, config *BenchmarkRunConfig) (AggregatedResultsMatrix, error) {
 	modes := []func(runs int, profile string, image string, method method, imageResults map[string][]float64) error{
 		runIterative,
 		runNonIterative,

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math"
 	"os/exec"
+	"strings"
 
 	"benchmark/pkg/command"
 )
@@ -21,8 +22,61 @@ type aggregatedRunResult struct {
 // AggregatedResultsMatrix is a map containing the run results for every image method combination.
 type AggregatedResultsMatrix map[string]map[string]aggregatedRunResult
 
+type BenchMarkRunConfig struct {
+	BenchMethods      map[string]struct{}
+	Iters             map[string]struct{}
+	Images            map[string]struct{}
+	MinikubeStartArgs []string
+	Profile           string
+}
+
+func NewBenchMarkRunConfig(profile, imageList, iterList, benchMethodList string, minikubeStartArgs []string) *BenchMarkRunConfig {
+	res := BenchMarkRunConfig{
+		BenchMethods:      make(map[string]struct{}),
+		Iters:             make(map[string]struct{}),
+		Images:            make(map[string]struct{}),
+		MinikubeStartArgs: minikubeStartArgs,
+		Profile:           profile,
+	}
+	var split []string
+	if imageList == "" {
+		split = Images
+	} else {
+		split = strings.Split(imageList, ",")
+	}
+	for _, image := range split {
+		res.Images[image] = struct{}{}
+	}
+
+	if iterList == "" {
+		split = Iter
+	} else {
+		split = strings.Split(iterList, ",")
+		for i, s := range split {
+			split[i] = " " + s
+		}
+	}
+	for _, iter := range split {
+		res.Iters[iter] = struct{}{}
+	}
+
+	if benchMethodList == "" {
+		for _, method := range BenchMethods {
+			res.BenchMethods[method.Name] = struct{}{}
+		}
+	} else {
+		split = strings.Split(benchMethodList, ",")
+		for _, method := range split {
+			res.BenchMethods[method] = struct{}{}
+		}
+	}
+
+	return &res
+
+}
+
 type method struct {
-	startMinikube func(profile string) error
+	startMinikube func(profile string, args ...string) error
 	bench         func(image string, profile string) (float64, error)
 	cacheClear    func(profile string) error
 	Name          string
@@ -116,7 +170,7 @@ var BenchMethods = []method{
 	}}
 
 // Run runs all the benchmarking combinations and returns the average run time and standard deviation for each combination.
-func Run(runs int, profile string) (AggregatedResultsMatrix, error) {
+func Run(runs int, config *BenchMarkRunConfig) (AggregatedResultsMatrix, error) {
 	modes := []func(runs int, profile string, image string, method method, imageResults map[string][]float64) error{
 		runIterative,
 		runNonIterative,
@@ -129,26 +183,50 @@ func Run(runs int, profile string) (AggregatedResultsMatrix, error) {
 	}
 
 	for _, method := range BenchMethods {
-		if err := method.startMinikube(profile); err != nil {
-			log.Printf("failed to start %s: %v", method.Name, err)
-			continue
+		skipMethod := false
+		if _, ok := config.BenchMethods[method.Name]; !ok {
+			skipMethod = true
 		}
 
-		for _, mode := range modes {
+		if !skipMethod {
+			// no need to start or delete if this method is completely skipped
+			if err := method.startMinikube(config.Profile, config.MinikubeStartArgs...); err != nil {
+				log.Printf("failed to start %s: %v", method.Name, err)
+				continue
+			}
+		}
+
+		for index, itr := range Iter {
 			for _, image := range Images {
 				imageResults := results[image]
 				if imageResults == nil {
 					imageResults = map[string][]float64{}
 				}
-				if err := mode(runs, profile, image, method, imageResults); err != nil {
-					log.Printf("failed to run benchmark %s: %v", method.Name, err)
+				// check we are going to skip this run
+				skipRun := skipMethod
+				if _, ok := config.Images[image]; !ok {
+					skipRun = true
+				}
+				if _, ok := config.Iters[itr]; !ok {
+					skipRun = true
+				}
+				if skipRun {
+					// skip this run
+					fmt.Printf("Benchmark %s on %s (%s) is skipped\n", image, method.Name, itr)
+				} else {
+					// run this method
+					if err := modes[index](runs, config.Profile, image, method, imageResults); err != nil {
+						log.Printf("failed to run benchmark %s: %v", method.Name, err)
+					}
 				}
 				results[image] = imageResults
 			}
 		}
 
-		if err := command.Delete(); err != nil {
-			log.Printf("failed to delete %s: %v", method.Name, err)
+		if !skipMethod {
+			if err := command.Delete(); err != nil {
+				log.Printf("failed to delete %s: %v", method.Name, err)
+			}
 		}
 	}
 

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -46,9 +46,8 @@ func NewBenchmarkRunConfig(profile, imageList, iterList, benchMethodList string,
 		res.Images[image] = struct{}{}
 	}
 
-	if iterList == "" {
-		split = Iter
-	} else {
+	split = Iter
+	if iterList != "" {
 		split = strings.Split(iterList, ",")
 		for i, s := range split {
 			split[i] = " " + s

--- a/pkg/command/dockerenv.go
+++ b/pkg/command/dockerenv.go
@@ -7,8 +7,8 @@ import (
 )
 
 // StartMinikubeDockerEnv starts minikube for docker-env.
-func StartMinikubeDockerEnv(profile string) error {
-	return startMinikube(profile)
+func StartMinikubeDockerEnv(profile string, args ...string) error {
+	return startMinikube(profile, args...)
 }
 
 // RunDockerEnv builds the provided image using the docker-env method and returns the run time.

--- a/pkg/command/imagebuild.go
+++ b/pkg/command/imagebuild.go
@@ -7,18 +7,20 @@ import (
 )
 
 // StartMinikubeImageBuildDocker starts minikube for docker image build.
-func StartMinikubeImageBuildDocker(profile string) error {
-	return startMinikube(profile)
+func StartMinikubeImageBuildDocker(profile string, args ...string) error {
+	return startMinikube(profile, args...)
 }
 
 // StartMinikubeImageBuildContainerd starts minikube for containerd image build.
-func StartMinikubeImageBuildContainerd(profile string) error {
-	return startMinikube(profile, "--container-runtime=containerd")
+func StartMinikubeImageBuildContainerd(profile string, args ...string) error {
+	arguments := append([]string{"--container-runtime=containerd"}, args...)
+	return startMinikube(profile, arguments...)
 }
 
 // StartMinikubeImageBuildCrio start minikube for crio image build.
-func StartMinikubeImageBuildCrio(profile string) error {
-	return startMinikube(profile, "--container-runtime=cri-o")
+func StartMinikubeImageBuildCrio(profile string, args ...string) error {
+	arguments := append([]string{"--container-runtime=cri-o"}, args...)
+	return startMinikube(profile, arguments...)
 }
 
 // RunImageBuild builds the provided image using the image build method and returns the run time.

--- a/pkg/command/imageload.go
+++ b/pkg/command/imageload.go
@@ -7,18 +7,19 @@ import (
 )
 
 // StartMinikubeImageLoadDocker starts minikube for docker image load.
-func StartMinikubeImageLoadDocker(profile string) error {
-	return startMinikube(profile)
+func StartMinikubeImageLoadDocker(profile string, args ...string) error {
+	return startMinikube(profile, args...)
 }
 
 // StartMinikubeImageLoadContainerd starts minikube for containerd image load.
-func StartMinikubeImageLoadContainerd(profile string) error {
+func StartMinikubeImageLoadContainerd(profile string, args ...string) error {
 	return startMinikube(profile, "--container-runtime=containerd")
 }
 
 // StartMinikubeImageLoadCrio start minikube for crio image load.
-func StartMinikubeImageLoadCrio(profile string) error {
-	return startMinikube(profile, "--container-runtime=cri-o")
+func StartMinikubeImageLoadCrio(profile string, args ...string) error {
+	arguments := append([]string{"--container-runtime=cri-o"}, args...)
+	return startMinikube(profile, arguments...)
 }
 
 // RunImageLoad builds the provided image using the image load method and returns the run time.

--- a/pkg/command/k3d.go
+++ b/pkg/command/k3d.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func StartK3d(profile string) error {
+func StartK3d(profile string, args ...string) error {
 	c := exec.Command("k3d", "cluster", "create", "benchmark")
 	if _, err := run(c); err != nil {
 		return fmt.Errorf("failed to start k3d: %v", err)

--- a/pkg/command/kind.go
+++ b/pkg/command/kind.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func StartKind(profile string) error {
+func StartKind(profile string, args ...string) error {
 	c := exec.Command("./kind", "create", "cluster")
 	if _, err := run(c); err != nil {
 		return fmt.Errorf("failed to start kind: %v", err)

--- a/pkg/command/microk8s.go
+++ b/pkg/command/microk8s.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func StartMicrok8s(profile string) error {
+func StartMicrok8s(profile string, args ...string) error {
 	c := exec.Command("microk8s", "start")
 	if _, err := run(c); err != nil {
 		return fmt.Errorf("failed to start microk8s: %v", err)

--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -7,23 +7,24 @@ import (
 )
 
 // StartMinikubeRegistryDocker starts minikube for docker registry.
-func StartMinikubeRegistryDocker(profile string) error {
-	return startMinikubeRegistry(profile, "docker")
+func StartMinikubeRegistryDocker(profile string, args ...string) error {
+	return startMinikubeRegistry(profile, "docker", args...)
 }
 
 // StartMinikubeRegistryContainerd starts minikube for containerd registry.
-func StartMinikubeRegistryContainerd(profile string) error {
-	return startMinikubeRegistry(profile, "containerd")
+func StartMinikubeRegistryContainerd(profile string, args ...string) error {
+	return startMinikubeRegistry(profile, "containerd", args...)
 }
 
 // StartMinikubeRegistryCrio start minikube for crio registry.
-func StartMinikubeRegistryCrio(profile string) error {
-	return startMinikubeRegistry(profile, "cri-o")
+func StartMinikubeRegistryCrio(profile string, args ...string) error {
+	return startMinikubeRegistry(profile, "cri-o", args...)
 }
 
-func startMinikubeRegistry(profile string, runtime string) error {
+func startMinikubeRegistry(profile string, runtime string, otherStartArgs ...string) error {
 	runtime = fmt.Sprintf("--container-runtime=%s", runtime)
-	if err := startMinikube(profile, runtime); err != nil {
+	arguments := append([]string{runtime}, otherStartArgs...)
+	if err := startMinikube(profile, arguments...); err != nil {
 		return err
 	}
 
@@ -32,7 +33,7 @@ func startMinikubeRegistry(profile string, runtime string) error {
 	}
 
 	// setDockerInsecureRegistry restarts docker, so minikube needs to be restarted
-	if err := startMinikube(profile, runtime); err != nil {
+	if err := startMinikube(profile, arguments...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When trying to run this benchmark in minikube's github action, some problems occurred:
1. Running this benchmark requires too much memory, which will make github action runner be offline because of lack of memory
2. Running this benchmark completely requires microk8s kind.... and so on, which is currently not available in github action vm
3. to many tests if we run tests for all the images. Total time to run all tests exceeds the maximum time limit of a girhub action runner

Therefore, some commandline arguments are added to support the following trivial features:
1. support choosing which test we need to run via command line arguments
2. support choosing which image we want to use via command line arguments 
3. support passing additional parameters to 'minikube start' so that we can use '--memory' to decrease the memory use of minikube

The Before-After comparasion:
T.B.D